### PR TITLE
updated shell_loop.c and commented out realloc section for tokens > 64

### DIFF
--- a/shell_loop.c
+++ b/shell_loop.c
@@ -165,8 +165,8 @@ int populateTokens(const char *input, char ***tokens, char **cmd_token,
 {
 	while ((*cmd_token) != NULL)
 	{
-		if ((*tokens_count) >= 64)
-			(*tokens) = realloc((*tokens), (*tokens_count) * sizeof(char *));
+		/* if ((*tokens_count) >= 64) */
+		/*	(*tokens) = realloc((*tokens), (*tokens_count) * sizeof(char *)); */
 
 		if ((*tokens) == NULL)
 		{
@@ -174,7 +174,7 @@ int populateTokens(const char *input, char ***tokens, char **cmd_token,
 			return (-1);
 		}
 
-		(*tokens)[(*tokens_count)] = strdup((*cmd_token));
+		(*tokens)[(*tokens_count)] = _strdup((*cmd_token));
 		(*cmd_token) = strtok(NULL, " \n\t\r");
 		(*tokens_count)++;
 	}


### PR DESCRIPTION
- shell_loop now has no unallowed functions
- removed realloc for tokens > 64