### PR TITLE
added a test script for quick testing in valgrind and nonvalgrind

### DIFF
--- a/test_script.sh
+++ b/test_script.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Define the valgrind command
+VALGRIND_CMD="valgrind --leak-check=full --show-reachable=yes --track-origins=yes -s ./hsh --ltrace"
+# VALGRIND_CMD="./hsh"  #non-valgrind version
+
+# Commands to test
+COMMANDS="ls
+whoami
+env
+cd -
+cd
+cd -
+unsetenv HOME
+cd
+setenv HOME /etc
+cd ~
+cd -"
+
+echo "===== Running in Non-Interactive Mode ====="
+echo "$COMMANDS" | $VALGRIND_CMD
+
+echo
+echo "===== Running in Interactive Mode ====="
+
+# Create a temporary file for interactive mode
+TMPFILE=$(mktemp)
+echo "$COMMANDS" > "$TMPFILE"
+
+# Run valgrind interactively using input redirection
+$VALGRIND_CMD < "$TMPFILE"
+
+# Clean up
+rm "$TMPFILE"


### PR DESCRIPTION
- test_script.sh
- run it as ./test_script.sh (might require chmod)
- add any tests to the COMMANDS string
- runs in both noninteractive and then interactive mode
- toggle between valgrind and non-valgrind
- takes 3 seconds
- only produces output; not unit tests