### PR TITLE
Updated FindPath

### DIFF
--- a/env2.c
+++ b/env2.c
@@ -54,7 +54,13 @@ char *findPath(char *name)
 {
 	path_t *temp = NULL;
 	path_t *head = NULL;
-	char *temp_path = NULL;
+	char *temp_path = NULL, *mallocd_name = NULL;
+
+	if (_strchr(name, '/') && !access(name, F_OK)) /* checks if path already */
+	{
+		mallocd_name = _strdup(name);
+		return (mallocd_name);
+	}
 
 	head = buildListPath(); /* populates list and points at head */
 	if (head == NULL)

--- a/executor.c
+++ b/executor.c
@@ -148,6 +148,9 @@ int execute_command(const char *commandPath, char **arguments)
 	pid_t pid;
 	int status;
 
+	if (!isCommand(commandPath))
+		return (1000);
+
 	pid = fork();
 	if (pid == -1)
 	{
@@ -181,4 +184,51 @@ int execute_command(const char *commandPath, char **arguments)
 		}
 	}
 	return 0; /* Success */
+}
+
+/**
+ * isCommand - Figures out whether the user filepath is an actual command
+ * @fp: user enetered command
+ *
+ * Return: 1 if a valid command, 0 if not, otherwise for specific error
+ */
+int isCommand(const char *fp)
+{
+	path_t *temp = NULL;
+	path_t *head = NULL;
+	char *temp_path = NULL;
+
+	if (_strchr(fp, '/') && access(fp, F_OK | X_OK)) /* checks if path already */
+		return (1);
+        // return (access(fp, F_OK | X_OK) == 0 ? 1 : 0);
+
+	head = buildListPath(); /* populates list and points at head */
+	if (!head)
+	{
+		return (-2); /*Return copy of fp*/
+	}
+	temp = head; /* iterator initialization */
+
+	while (temp != NULL) /* run until list is empty */
+	{					 /* malloc space for path/fp\0 */
+		temp_path = malloc(_strlen(temp->directory) + _strlen(fp) + 2);
+		if (temp_path == NULL)
+		{
+			destroyListPath(head);
+			return (-1);
+		}
+		_strcpy(temp_path, temp->directory);
+		_strcat(temp_path, "/");
+		_strcat(temp_path, fp);
+		if (access(temp_path, F_OK) == 0) /* checks if cmd at path exists */
+		{
+			destroyListPath(head); /* frees list of paths */
+			free(temp_path);
+			return (1);	   /* returns found path + fp */
+		}
+		free(temp_path);   /* frees temp_path */
+		temp = temp->next; /* go to next location */
+	}
+	destroyListPath(head);
+	return (0);		   /* not a valid filepath. consider returning errno? */
 }

--- a/executor.c
+++ b/executor.c
@@ -148,8 +148,10 @@ int execute_command(const char *commandPath, char **arguments)
 	pid_t pid;
 	int status;
 
-	// if (!isCommand(commandPath))
-	// 	return (1000);
+	// int isCommandRtn = isCommand(commandPath);
+	// printf("\nisCommand: %d\n\n", isCommandRtn);
+	// // if (isCommandRtn)
+	// // 	printf("\nisCommand: %d\n\n", isCommandRtn);
 
 	pid = fork();
 	if (pid == -1)
@@ -198,7 +200,7 @@ int isCommand(const char *fp)
 	path_t *head = NULL;
 	char *temp_path = NULL;
 
-	if (_strchr(fp, '/') && access(fp, F_OK | X_OK)) /* checks if path already */
+	if (_strchr(fp, '/') && !access(fp, F_OK)) /* checks if path already */
 		return (1);
         // return (access(fp, F_OK | X_OK) == 0 ? 1 : 0);
 

--- a/main.c
+++ b/main.c
@@ -87,6 +87,8 @@ void executeIfValid(int isAtty, char *const *argv, char **tokens, char *input)
 			}
 			else if(run_cmd_rtn == 2)
 				;
+			else if(run_cmd_rtn == 1000)
+				fprintf(stderr, "%s: 1: %s: not found\n", argv[0], tokens[0]);
 			else
 			{
 				/* Other execve errors: use perror to print a descriptive message */

--- a/main.c
+++ b/main.c
@@ -75,6 +75,7 @@ void executeIfValid(int isAtty, char *const *argv, char **tokens, char *input)
 		fprintf(stderr, "%s: 1: %s: not found\n", argv[0], tokens[0]);
 		if (!isAtty)
 		{
+			resetAll(tokens, input, NULL);
 			safeExit(127);
 		}
 		return; /* Return here after handling "not found" */

--- a/main.h
+++ b/main.h
@@ -99,6 +99,7 @@ int _atoi_safe(const char *s);
 void resetAll(char **tokens, ...);
 void freeIfCmdCd(char *previous_cwd, char *home, char *pwd);
 int is_directory(char *fp);
+int isCommand(const char *fp);
 
 /* --- Custom String Functions (Keep these!) --- */
 char *_strcat(char *dest, const char *src);

--- a/test_script.sh
+++ b/test_script.sh
@@ -21,7 +21,7 @@ cd /root
  
     
        
-" # add fakeCmd at some point
+fake"
 
 echo "===== Running in Non-Interactive Mode ====="
 echo "$COMMANDS" | $VALGRIND_CMD


### PR DESCRIPTION
- Added a section to ensure it returns a malloc'd name if the token[0] is already a relative/absolute path to a command.
- added a resetAll() just before a safeExit() for nonAtty
- added isCommand ... that might already be deprecated. it returns 1 or 0 if a filepath is a valid command